### PR TITLE
kernel-builder-k8s-job: modify kernel config options

### DIFF
--- a/playbooks/roles/kernel-builder-k8s-job/templates/build-kernel.sh
+++ b/playbooks/roles/kernel-builder-k8s-job/templates/build-kernel.sh
@@ -53,7 +53,12 @@ yes "" | make olddefconfig
 ./scripts/config --enable CONFIG_DEBUG_FS
 ./scripts/config --enable CONFIG_BLK_DEBUG_FS
 ./scripts/config --enable CONFIG_TARGET_DEBUG_FS
+./scripts/config --enable CONFIG_NVME_TARGET_DEBUGFS
 ./scripts/config --enable CONFIG_DEBUG_ATOMIC_SLEEP
+./scripts/config --enable CONFIG_FAULT_INJECTION
+./scripts/config --enable CONFIG_FAULT_INJECTION_DEBUG_FS
+./scripts/config --enable CONFIG_BLK_DEV_NULL_BLK_FAULT_INJECTION
+./scripts/config --enable CONFIG_FAIL_MAKE_REQUEST
 # Build in CONFIG_IP_NF_IPTABLES for podman
 # https://github.com/microsoft/WSL/issues/12108
 ./scripts/config --enable CONFIG_IP_NF_IPTABLES


### PR DESCRIPTION
Enable some more kernel config options to not skip some blktests test cases which require fault injection and debugfs features.