### PR TITLE
kernel-builder-k8s-job: modify kernel config options for LOCKDEP bits

### DIFF
--- a/playbooks/roles/kernel-builder-k8s-job/templates/build-kernel.sh
+++ b/playbooks/roles/kernel-builder-k8s-job/templates/build-kernel.sh
@@ -59,6 +59,8 @@ yes "" | make olddefconfig
 ./scripts/config --enable CONFIG_FAULT_INJECTION_DEBUG_FS
 ./scripts/config --enable CONFIG_BLK_DEV_NULL_BLK_FAULT_INJECTION
 ./scripts/config --enable CONFIG_FAIL_MAKE_REQUEST
+./scripts/config --set-val CONFIG_LOCKDEP_BITS 21
+./scripts/config --set-val CONFIG_LOCKDEP_CHAINS_BITS 21
 # Build in CONFIG_IP_NF_IPTABLES for podman
 # https://github.com/microsoft/WSL/issues/12108
 ./scripts/config --enable CONFIG_IP_NF_IPTABLES


### PR DESCRIPTION
The blktests test case block/027 fails due to the kernel "BUG: MAX_LOCKDEP_CHAIN_HLOCKS too low!". To suppress the BUG message, increase the config option values of LOCKDEP_BITS and LOCKDEP_CHAINS_BITS.