### PR TITLE
kubevirt-actions: fix action for running multiple VMs

### DIFF
--- a/.github/actions/kubevirt-action/action.yaml
+++ b/.github/actions/kubevirt-action/action.yaml
@@ -43,12 +43,20 @@ runs:
       shell: bash
       run: |
         source vars.sh
+        rm -rf artifacts
         mkdir artifacts
         ./virtctl scp "${ssh_options[@]}" -r ${vm_user}@${vm_name}:/home/${vm_user}/${{ inputs.vm_artifact_upload_dir }} artifacts
+      if: ${{ always() && inputs.vm_artifact_upload_dir != '' }}
+    - name: Create timestamp env var
+      shell: bash
+      run: |
+        ts=$(date +'%Y%m%d-%H%M%S')
+        echo "TS=$ts" >> $GITHUB_ENV
       if: ${{ always() && inputs.vm_artifact_upload_dir != '' }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
+        name: artifact-${{ env.TS }}
         path: |
           ./artifacts
       if: ${{ always() && inputs.vm_artifact_upload_dir != '' }}

--- a/.github/actions/kubevirt-action/entrypoint.sh
+++ b/.github/actions/kubevirt-action/entrypoint.sh
@@ -23,7 +23,9 @@ KUBEVIRT_VERSION=$(./kubectl get kubevirt.kubevirt.io/kubevirt -n kubevirt -o=js
 curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-amd64
 sudo chmod +x virtctl
 
-ssh-keygen -b 2048 -t rsa -f ./identity -q -N ""
+if [ ! -f ./identity ]; then
+  ssh-keygen -b 2048 -t rsa -f ./identity -q -N ""
+fi
 export vm_ssh_authorized_keys=$(cat ./identity.pub | xargs)
 export kernel_version=$INPUT_KERNEL_VERSION
 


### PR DESCRIPTION
1. Do not attempt to regenerate the ssh key when running this action multiple times.

2. Make sure to clean the artifacts upload directory for each run.

3. Provide a different artifact upload name for each run.