### PR TITLE
Preparation for dual cluster runners

### DIFF
--- a/.github/actions/kubevirt-action/action.yaml
+++ b/.github/actions/kubevirt-action/action.yaml
@@ -17,6 +17,10 @@ inputs:
   vm_artifact_upload_dir:
     description: "VM directory of artifacts to upload"
     required: false
+  host_devices:
+    description: "Comma-separated list of host device short names to attach to the VM (e.g. nvme-wdc-zn540,nvme-wdc-zn540,nvme-wdc-sn640). Duplicates request multiple devices of the same type. If empty, auto-discovers all available devices.kubevirt.io/* devices from node allocatable resources."
+    required: false
+    default: ""
 
 outputs:
   stdout:
@@ -44,6 +48,7 @@ runs:
         GITHUB_ACTION_PATH: "${{ github.action_path }}"
         INPUT_KERNEL_VERSION: "${{ inputs.kernel_version }}"
         INPUT_RUN_CMDS: "${{ inputs.run_cmds }}"
+        INPUT_HOST_DEVICES: "${{ inputs.host_devices }}"
     - name: Create timestamp env var for artifact uploads
       shell: bash
       run: |

--- a/.github/actions/kubevirt-action/entrypoint.sh
+++ b/.github/actions/kubevirt-action/entrypoint.sh
@@ -24,6 +24,52 @@ function install_requirements() {
   unzip -o logcli-linux-amd64.zip
 }
 
+function resolve_host_devices() {
+  local devices_json="[]"
+
+  if [ -n "${INPUT_HOST_DEVICES:-}" ]; then
+    # Parse comma-separated short device names into a JSON array
+    # Duplicates are supported to request multiple devices of the same type
+    declare -A device_counters
+    devices_json="["
+    local first=true
+    IFS=',' read -ra DEVICES <<< "${INPUT_HOST_DEVICES}"
+    for dev in "${DEVICES[@]}"; do
+      dev=$(echo "$dev" | xargs) # trim whitespace
+      [ -z "$dev" ] && continue
+      local count=${device_counters[$dev]:-0}
+      device_counters[$dev]=$((count + 1))
+      local name="${dev}-${count}"
+      if [ "$first" = true ]; then
+        first=false
+      else
+        devices_json+=","
+      fi
+      devices_json+="{\"name\":\"${name}\",\"deviceName\":\"devices.kubevirt.io/${dev}\"}"
+    done
+    devices_json+="]"
+  else
+    # Auto-discover PCI host devices: query KubeVirt CR for permitted
+    # pciHostDevices, then cross-reference with node allocatable resources
+    permitted=$(./kubectl get kubevirt.kubevirt.io/kubevirt -n kubevirt -o json \
+      | jq -c '[.spec.configuration.permittedHostDevices.pciHostDevices[].resourceName] | unique')
+    devices_json=$(./kubectl get nodes -o json | jq -c --argjson permitted "$permitted" '
+      [.items[].status.allocatable // {} | to_entries[]
+        | select(.key as $k | $permitted | index($k))
+        | select(.value != "0")]
+      | unique_by(.key)
+      | to_entries
+      | map({
+          name: (.value.key | ltrimstr("devices.kubevirt.io/") | . + "-0"),
+          deviceName: .value.key
+        })
+    ')
+  fi
+
+  export host_devices="${devices_json}"
+  echo "Resolved host devices: ${host_devices}"
+}
+
 function run_ssh_cmds() {
   if [ ! -f ./identity ]; then
     ssh-keygen -b 2048 -t rsa -f ./identity -q -N ""
@@ -35,12 +81,23 @@ function run_ssh_cmds() {
     export mitmproxy_ca_cert=$(cat /etc/ssl/certs/mitmproxy-ca-cert.pem)
   fi
 
+  resolve_host_devices
+
   # Render cloud-init script and create a ConfigMap for the VM to consume via virtiofs
   j2 $(dirname "$0")/../../../playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/fedora-vm-init.sh.j2 -o init.sh
   ./kubectl create configmap ${vm_name}-cloud-init --from-file=init.sh=init.sh --dry-run=client -o yaml | ./kubectl apply -f -
 
+  # Write YAML data file for VM template rendering (host_devices is a JSON
+  # array which is valid YAML, so j2 parses it into a native list of dicts)
+  cat > vm-data.yaml << EOF
+vm_name: "${vm_name}"
+kernel_version: "${kernel_version}"
+vm_ssh_authorized_keys: "${vm_ssh_authorized_keys}"
+host_devices: ${host_devices}
+EOF
+
   # Render and create VM
-  j2 $(dirname "$0")/../../../playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/fedora-var-kernel-vm.yaml.j2 -o vm.yml
+  j2 $(dirname "$0")/../../../playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/fedora-var-kernel-vm.yaml.j2 vm-data.yaml -o vm.yml
   ./kubectl create -f vm.yml
   ./kubectl wait vm ${vm_name} --for=jsonpath='{.status.printableStatus}'=Running --timeout=300s
   while true; do

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/tasks/main.yaml
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/tasks/main.yaml
@@ -109,7 +109,8 @@
     chart_version: "{{ gha_rss_version }}"
     chart_ref: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
     values: "{{ arc_controller_proxy_values | default({}) }}"
-  when: arc_installed.rc != 0
+  when: arc_installed.rc != 0 or (arc_installed.rc == 0 and arc_installed_version.stdout != gha_rss_version)
+
 
 - name: "Create Kubernetes secret for the github_token of {{ runner_set_name }}"
   kubernetes.core.k8s:
@@ -190,6 +191,32 @@
               fi
             fi
           done
+
+- name: "Extract repo name from github_config_url (used for gha-runner-scale-set label)"
+  set_fact:
+    repo_name: "{{ github_config_url | urlsplit('path') | basename }}"
+
+- name: "Query KubeVirt CR for permitted PCI host devices"
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: KubeVirt
+    name: kubevirt
+    namespace: kubevirt
+  register: kubevirt_cr
+
+- name: "Collect permitted PCI device resource names from KubeVirt CR"
+  set_fact:
+    permitted_pci_devices: "{{ kubevirt_cr.resources[0].spec.configuration.permittedHostDevices.pciHostDevices | default([]) | map(attribute='resourceName') | unique | list }}"
+
+- name: "Query cluster nodes for allocatable resources"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Node
+  register: cluster_nodes
+
+- name: "Build PCI device labels from devices that are both permitted and allocatable (used for gha-runner-scale-set)"
+  set_fact:
+    pci_device_labels: "{{ cluster_nodes.resources | map(attribute='status.allocatable', default={}) | map('dict2items') | flatten | selectattr('key', 'in', permitted_pci_devices) | selectattr('value', '!=', '0') | map(attribute='key') | map('regex_replace', '^devices.kubevirt.io/', '') | unique | list }}"
 
 - name: "Ensure ~/tmp-ansible exists"
   file:

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/tasks/main.yaml
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/tasks/main.yaml
@@ -85,6 +85,21 @@
   register: arc_installed
   ignore_errors: true
 
+- name: Get installed ARC controller chart version
+  shell: helm list -n arc-systems -o json | python3 -c "import sys,json; entries=[e for e in json.load(sys.stdin) if e['name']=='arc']; print(entries[0]['chart'].split('-')[-1] if entries else '')"
+  register: arc_installed_version
+  when: arc_installed.rc == 0
+
+#https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations
+- name: "Update ARC controller CRDs (Helm does not update CRDs that already exist)"
+  shell: |
+    helm pull oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller \
+      --version {{ gha_rss_version }} --untar --untardir /tmp/arc-crds && \
+    kubectl apply --server-side --force-conflicts \
+      -f /tmp/arc-crds/gha-runner-scale-set-controller/crds/ && \
+    rm -rf /tmp/arc-crds
+  when: arc_installed.rc == 0 and arc_installed_version.stdout != gha_rss_version
+
 #https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/quickstart-for-actions-runner-controller
 - name: "Install the Actions Runner Controller, which is controlling all runner sets we will deploy"
   kubernetes.core.helm:
@@ -188,12 +203,6 @@
   vars:
     github_config_secret: "github-config-secret"
 
-- name: Check if arc-vm-* package is installed
-  shell: |
-    helm list -n gh-runner-{{ runner_set_name }} -q | grep -w arc-vm-{{ runner_set_name }}
-  register: arc_kernel_builder_installed
-  ignore_errors: true
-
 - name: Setup service account for kubevirt-actions-runner to manage VMs
   kubernetes.core.k8s:
     state: present
@@ -207,4 +216,3 @@
     chart_version: "{{ gha_rss_version }}"
     chart_ref: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
     values_files: "{{ lookup('ansible.builtin.env', 'HOME') }}/tmp-ansible/arc-vm-scale-set-values.yaml"
-  when: arc_kernel_builder_installed.rc != 0

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/arc-vm-scale-set-values.yaml.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/arc-vm-scale-set-values.yaml.j2
@@ -8,6 +8,11 @@ githubConfigUrl: "{{ github_config_url }}"
 githubConfigSecret: "{{ github_config_secret }}"
 maxRunners: 3
 minRunners: 0
+scaleSetLabels:
+  - "arc-vm-{{ repo_name }}"
+{% for label in pci_device_labels | default([]) %}
+  - "{{ label }}"
+{% endfor %}
 {% if mitmproxy_enabled %}
 githubServerTLS:
   certificateFrom:

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/fedora-var-kernel-vm.yaml.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/fedora-var-kernel-vm.yaml.j2
@@ -44,11 +44,13 @@ spec:
           interfaces:
             - name: default
               masquerade: {}
+{% if host_devices %}
           hostDevices:
-            - name: nvme-zns-0
-              deviceName: devices.kubevirt.io/nvme-wdc-zn540
-            - name: nvme-conv-0
-              deviceName: devices.kubevirt.io/nvme-wdc-sn640
+{% for dev in host_devices %}
+            - name: {{ dev.name }}
+              deviceName: {{ dev.deviceName }}
+{% endfor %}
+{% endif %}
         cpu:
           cores: 4
         resources:

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/kubevirt-actions-runner-rbac.yaml.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/kubevirt-actions-runner-rbac.yaml.j2
@@ -45,3 +45,25 @@ roleRef:
   kind: Role
   name: kubevirt-actions-runner
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-actions-runner-node-reader-{{ runner_set_name }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-actions-runner-node-reader-{{ runner_set_name }}
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-actions-runner
+    namespace: "gh-runner-{{ runner_set_name }}"
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-actions-runner-node-reader-{{ runner_set_name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/variables.yaml
+++ b/variables.yaml
@@ -23,7 +23,7 @@ kubevirt_version: "v1.7.0"
 kubevirt_cri_version: "v1.64.0"
 
 #gha-runner-scale-set
-gha_rss_version: "0.13.1"
+gha_rss_version: "0.14.1"
 
 #mitmproxy
 # Optional: Set corporate_ca_cert_path to the path of your corporate SSL MITM


### PR DESCRIPTION
This PR is preparing the blktests-ci to be runnable on multiple different k8s clusters, serving the same repositories.

We expose cluster specific hardware configurations via runner labels.
To address any of the runner scale set deployed in different clusters we can simply use `runs-on: arc-vm-<repo-name>` in the workflow file.



