### PR TITLE
kubevirt-action: find dmesg launcher pod by UID label

### DIFF
--- a/.github/actions/kubevirt-action/entrypoint.sh
+++ b/.github/actions/kubevirt-action/entrypoint.sh
@@ -148,8 +148,9 @@ function extract_dmesg_logs() {
   rm -rf dmesg-logs
   mkdir dmesg-logs
   ./kubectl describe vmi $vm_name > ./dmesg-logs/vmi-description.log
-  log_pod_name=$(./kubectl get pods | grep -o "virt-launcher-${vm_name}-[^ ]*" | xargs)
-  since_time=$(./kubectl get pods | grep "virt-launcher-${vm_name}-[^ ]*" | awk '{print $5}' | xargs)
+  vmi_uid=$(./kubectl get vmi "${vm_name}" -o jsonpath='{.metadata.uid}')
+  log_pod_name=$(./kubectl get pods -l kubevirt.io/created-by="${vmi_uid}" -o jsonpath='{.items[0].metadata.name}')
+  since_time=$(./kubectl get pods -l kubevirt.io/created-by="${vmi_uid}" --no-headers | awk 'NR==1{print $5}' | xargs)
   ./logcli-linux-amd64 --addr=http://loki.logging.svc.cluster.local:3100 query "{container=\"guest-console-log\", pod=\"${log_pod_name}\"}" --limit=0 --since=${since_time} > ./dmesg-logs/dmesg.log
 }
 


### PR DESCRIPTION
extract_dmesg_logs located the virt-launcher pod by grepping "kubectl get pods" for "virt-launcher-${vm_name}-". That broke once vm_name started embedding the repository slug: although vm_name itself stays within Kubernetes' 63-character limit, the launcher pod prepends "virt-launcher-" (14 chars) and appends a "-<random>" suffix, so Kubernetes truncates the generated name (base capped at 58 chars). The trailing CI run id gets chopped off, the grep matches nothing, log_pod_name ends up empty, and set -o pipefail aborts the step with exit code 1.

Look the pod up by the kubevirt.io/created-by=<vmi-uid> label that KubeVirt stamps on every launcher pod instead. This is how KubeVirt locates launcher pods internally and is immune to name truncation, unlike the deprecated vm.kubevirt.io/name label.