### PR TITLE
kubevirt-action: support ubuntu/debian/opensuse container disks

### DIFF
--- a/.github/actions/kubevirt-action/action.yaml
+++ b/.github/actions/kubevirt-action/action.yaml
@@ -26,6 +26,18 @@ inputs:
     description: "Container disk image backing the VM's root volume. If omitted, defaults to the pinned Fedora cloud image from the VM template."
     required: false
     default: ""
+  distro:
+    description: "Base image distro family: fedora, ubuntu, debian or opensuse. Selects the package manager and CA-trust layout used to provision the VM. If omitted, it is inferred from container_disk_image."
+    required: false
+    default: ""
+  root_device:
+    description: "Root block device the custom kernel boots from, e.g. /dev/vda1. Only used when kernel_version is set. If omitted, a per-distro default is used."
+    required: false
+    default: ""
+  root_flags:
+    description: "Root mount flags for the custom kernel boot, e.g. subvol=root for btrfs. Only used when kernel_version is set. If omitted, a per-distro default is used."
+    required: false
+    default: ""
 
 outputs:
   stdout:
@@ -55,6 +67,9 @@ runs:
         INPUT_RUN_CMDS: "${{ inputs.run_cmds }}"
         INPUT_HOST_DEVICES: "${{ inputs.host_devices }}"
         INPUT_CONTAINER_DISK_IMAGE: "${{ inputs.container_disk_image }}"
+        INPUT_DISTRO: "${{ inputs.distro }}"
+        INPUT_ROOT_DEVICE: "${{ inputs.root_device }}"
+        INPUT_ROOT_FLAGS: "${{ inputs.root_flags }}"
     - name: Create timestamp env var for artifact uploads
       shell: bash
       run: |

--- a/.github/actions/kubevirt-action/entrypoint.sh
+++ b/.github/actions/kubevirt-action/entrypoint.sh
@@ -142,8 +142,10 @@ function run_ssh_cmds() {
 
   resolve_host_devices
 
-  # Render cloud-init script and create a ConfigMap for the VM to consume via virtiofs
-  j2 ${TEMPLATES_DIR}/fedora-vm-init.sh.j2 -o init.sh
+  # Render cloud-init script and create a ConfigMap for the VM to consume via
+  # virtiofs (j2 with no data file renders from the exported environment, e.g.
+  # distro, vm_user, kernel_version, mitmproxy_ca_cert)
+  j2 ${TEMPLATES_DIR}/vm-init.sh.j2 -o init.sh
   kubectl create configmap ${vm_name}-cloud-init --from-file=init.sh=init.sh --dry-run=client -o yaml | kubectl apply -f -
 
   # Write YAML data file for VM template rendering (host_devices is a JSON
@@ -154,10 +156,14 @@ kernel_version: "${kernel_version}"
 vm_ssh_authorized_keys: "${vm_ssh_authorized_keys}"
 host_devices: ${host_devices}
 container_disk_image: "${container_disk_image}"
+distro: "${distro}"
+vm_user: "${vm_user}"
+root_device: "${root_device}"
+root_flags: "${root_flags}"
 EOF
 
   # Render and create VM
-  j2 ${TEMPLATES_DIR}/fedora-var-kernel-vm.yaml.j2 vm-data.yaml -o vm.yml
+  j2 ${TEMPLATES_DIR}/vm.yaml.j2 vm-data.yaml -o vm.yml
   kubectl create -f vm.yml
   # EFI/OVMF boot plus enumeration of a passed-through HBA option ROM makes
   # host-device VMs noticeably slower to reach "Running"; the previous 300s was

--- a/.github/actions/kubevirt-action/vars.sh
+++ b/.github/actions/kubevirt-action/vars.sh
@@ -39,7 +39,9 @@ if [ "${max_repo_len}" -gt 0 ] && [ -n "${repo_slug}" ]; then
 else
   export vm_name="vm-runner-${vm_suffix}"
 fi
-export vm_user="fedora"
+# Every VM provisions its own dedicated login user via cloud-init, so the SSH
+# user is fixed regardless of the base image's default cloud user.
+export vm_user="runner"
 export ssh_options=(--identity-file=$(realpath ./identity | xargs) --local-ssh-opts="-o StrictHostKeyChecking=no")
 
 # Container disk image backing the VM's root volume. Optional override exposed
@@ -48,3 +50,26 @@ export ssh_options=(--identity-file=$(realpath ./identity | xargs) --local-ssh-o
 # INPUT_CONTAINER_DISK_IMAGE. When left empty the VM template falls back to its
 # pinned default.
 export container_disk_image="${INPUT_CONTAINER_DISK_IMAGE:-}"
+
+# Distro family of the base image. It selects the package manager and CA-trust
+# layout used to provision the VM, and the root device/flags for custom-kernel
+# boots. It is inferred from the container disk image reference (matching the
+# quay.io/containerdisks naming) but can be overridden with the `distro` input
+# (INPUT_DISTRO) for mirrored or renamed images. Defaults to fedora if
+# undecided.
+detect_distro() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    *fedora*) echo fedora ;;
+    *ubuntu*) echo ubuntu ;;
+    *debian*) echo debian ;;
+    *opensuse*|*suse*|*tumbleweed*|*leap*|*microos*) echo opensuse ;;
+    *) echo fedora ;;
+  esac
+}
+export distro="${INPUT_DISTRO:-$(detect_distro "${container_disk_image}")}"
+
+# Optional overrides for the root filesystem location the custom kernel boots
+# from (only used when kernel_version is set). Empty means "use the per-distro
+# default baked into the VM template".
+export root_device="${INPUT_ROOT_DEVICE:-}"
+export root_flags="${INPUT_ROOT_FLAGS:-}"

--- a/ci/gitlab/Dockerfile.kubevirt-runner
+++ b/ci/gitlab/Dockerfile.kubevirt-runner
@@ -37,8 +37,8 @@ COPY --from=dockercli /usr/local/bin/docker /usr/local/bin/docker
 # kubevirt entrypoint, the vars it sources, and the VM templates it renders.
 COPY .github/actions/kubevirt-action/entrypoint.sh /opt/kubevirt-runner/entrypoint.sh
 COPY .github/actions/kubevirt-action/vars.sh /opt/kubevirt-runner/vars.sh
-COPY playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/fedora-vm-init.sh.j2 /opt/kubevirt-runner/templates/fedora-vm-init.sh.j2
-COPY playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/fedora-var-kernel-vm.yaml.j2 /opt/kubevirt-runner/templates/fedora-var-kernel-vm.yaml.j2
+COPY playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2 /opt/kubevirt-runner/templates/vm-init.sh.j2
+COPY playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm.yaml.j2 /opt/kubevirt-runner/templates/vm.yaml.j2
 
 RUN chmod +x /opt/kubevirt-runner/entrypoint.sh /opt/kubevirt-runner/vars.sh
 

--- a/ci/gitlab/kubevirt.gitlab-ci.yml
+++ b/ci/gitlab/kubevirt.gitlab-ci.yml
@@ -56,12 +56,23 @@
     # Container disk image backing the VM root volume. If left empty, the VM
     # uses the pinned default image from the VM template.
     KUBEVIRT_CONTAINER_DISK_IMAGE: ""
+    # Base image distro family: fedora, ubuntu, debian or opensuse. Selects the
+    # package manager and CA-trust layout used to provision the VM. If left
+    # empty, it is inferred from the container disk image.
+    KUBEVIRT_DISTRO: ""
+    # Root device/flags the custom kernel boots from (only used when
+    # KUBEVIRT_KERNEL_VERSION is set). If left empty, per-distro defaults apply.
+    KUBEVIRT_ROOT_DEVICE: ""
+    KUBEVIRT_ROOT_FLAGS: ""
     # ---- Wiring (do not normally override) ------------------------------
     # Map the friendly variables to the names the entrypoint expects.
     INPUT_KERNEL_VERSION: "$KUBEVIRT_KERNEL_VERSION"
     INPUT_RUN_CMDS: "$KUBEVIRT_RUN_CMDS"
     INPUT_HOST_DEVICES: "$KUBEVIRT_HOST_DEVICES"
     INPUT_CONTAINER_DISK_IMAGE: "$KUBEVIRT_CONTAINER_DISK_IMAGE"
+    INPUT_DISTRO: "$KUBEVIRT_DISTRO"
+    INPUT_ROOT_DEVICE: "$KUBEVIRT_ROOT_DEVICE"
+    INPUT_ROOT_FLAGS: "$KUBEVIRT_ROOT_FLAGS"
     # Talk to the docker:dind service over plain TCP (shared pod localhost).
     DOCKER_HOST: "tcp://localhost:2375"
     DOCKER_TLS_CERTDIR: ""
@@ -77,7 +88,7 @@
       if git clone --depth 1 --branch main https://github.com/linux-blktests/blktests-ci.git "$src"; then
         install -m 0755 "$src/.github/actions/kubevirt-action/entrypoint.sh" /opt/kubevirt-runner/entrypoint.sh
         install -m 0755 "$src/.github/actions/kubevirt-action/vars.sh"       /opt/kubevirt-runner/vars.sh
-        install -m 0644 "$src"/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/fedora-*.j2 /opt/kubevirt-runner/templates/
+        install -m 0644 "$src"/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm.yaml.j2 "$src"/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2 /opt/kubevirt-runner/templates/
         echo "kubevirt CI logic synced from linux-blktests/blktests-ci@main"
       else
         echo "WARNING: failed to clone linux-blktests/blktests-ci@main; using image-baked logic."

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2
@@ -14,8 +14,8 @@ set -ex
 # `|| true` / `if !` commands below.
 trap 'rc=$?; echo "init.sh failed (exit ${rc}) at line ${LINENO}: ${BASH_COMMAND}" > /vm-init-failed 2>/dev/null || true; exit "${rc}"' ERR
 
-# Retry a (typically network-dependent) command a few times. Transient dnf /
-# registry / proxy hiccups otherwise abort init before /vm-ready is created.
+# Retry a (typically network-dependent) command a few times. Transient package
+# manager / registry / proxy hiccups otherwise abort init before /vm-ready.
 retry() {
   local n=1 max=5 delay=10
   until "$@"; do
@@ -29,6 +29,34 @@ retry() {
   done
 }
 
+distro="{{ distro | default('fedora', true) }}"
+vm_user="{{ vm_user | default('runner', true) }}"
+
+case "$distro" in
+  ubuntu|debian)
+    pkg_install() { apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"; }
+    ca_anchor_dir="/usr/local/share/ca-certificates"
+    ca_cert_ext="crt"
+    ca_update_cmd="update-ca-certificates"
+    sg3_utils_pkg="sg3-utils"
+    ;;
+  opensuse)
+    pkg_install() { zypper --non-interactive install "$@"; }
+    ca_anchor_dir="/etc/pki/trust/anchors"
+    ca_cert_ext="pem"
+    ca_update_cmd="update-ca-certificates"
+    sg3_utils_pkg="sg3_utils"
+    ;;
+  *)
+    # fedora and other dnf-based (rhel/centos/almalinux) images
+    pkg_install() { dnf install -y "$@"; }
+    ca_anchor_dir="/etc/pki/ca-trust/source/anchors"
+    ca_cert_ext="pem"
+    ca_update_cmd="update-ca-trust"
+    sg3_utils_pkg="sg3_utils"
+    ;;
+esac
+
 {% if mitmproxy_ca_cert is defined and mitmproxy_ca_cert %}
 cat > /etc/profile.d/proxy.sh << 'EOF'
 export HTTP_PROXY=http://mitmproxy.mitmproxy.svc.cluster.local:8080
@@ -38,6 +66,8 @@ export http_proxy=http://mitmproxy.mitmproxy.svc.cluster.local:8080
 export https_proxy=http://mitmproxy.mitmproxy.svc.cluster.local:8080
 export no_proxy=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.svc.cluster.local,container-registry.local
 EOF
+# Export into the current shell too so the package manager below picks up the
+# proxy (cloud-init runcmd is not a login shell and does not read profile.d).
 source /etc/profile.d/proxy.sh
 
 cat >> /etc/environment << 'EOF'
@@ -49,9 +79,23 @@ https_proxy=http://mitmproxy.mitmproxy.svc.cluster.local:8080
 no_proxy=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.svc.cluster.local,container-registry.local
 EOF
 
-cat >> /etc/dnf/dnf.conf << 'EOF'
+# Package-manager proxy. dnf and apt need explicit config; zypper honours the
+# http(s)_proxy env vars exported above.
+case "$distro" in
+  ubuntu|debian)
+    cat > /etc/apt/apt.conf.d/95proxy << 'EOF'
+Acquire::http::Proxy "http://mitmproxy.mitmproxy.svc.cluster.local:8080";
+Acquire::https::Proxy "http://mitmproxy.mitmproxy.svc.cluster.local:8080";
+EOF
+    ;;
+  opensuse)
+    ;;
+  *)
+    cat >> /etc/dnf/dnf.conf << 'EOF'
 proxy=http://mitmproxy.mitmproxy.svc.cluster.local:8080
 EOF
+    ;;
+esac
 
 mkdir -p /etc/systemd/system/docker.service.d
 cat > /etc/systemd/system/docker.service.d/proxy.conf << 'EOF'
@@ -61,10 +105,11 @@ Environment="HTTPS_PROXY=http://mitmproxy.mitmproxy.svc.cluster.local:8080"
 Environment="NO_PROXY=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.svc.cluster.local,container-registry.local"
 EOF
 
-cat > /etc/pki/ca-trust/source/anchors/mitmproxy-ca-cert.pem << 'CERT'
+install -d -m 0755 "$ca_anchor_dir"
+cat > "${ca_anchor_dir}/mitmproxy-ca-cert.${ca_cert_ext}" << 'CERT'
 {{ mitmproxy_ca_cert }}
 CERT
-update-ca-trust
+$ca_update_cmd
 {% endif %}
 
 mkdir -p /mnt/prepare-nvme-devices
@@ -80,16 +125,40 @@ tar -xvf /mnt/kernel-modules-disk/kernel_m.tgz --directory /usr/lib/modules/
 depmod "$(uname -r)"
 {% endif %}
 modprobe tun
-loginctl enable-linger fedora
+loginctl enable-linger "$vm_user"
 
-retry dnf -y install podman jq nvme-cli sg3_utils lsscsi
+retry pkg_install sudo podman jq nvme-cli "$sg3_utils_pkg" lsscsi
 
+# A passed-through SAS HBA needs the mpt3sas driver. It is usually built into or
+# already shipped with the distro kernel; on Fedora the driver lives in the
+# kernel-modules(-extra) package, so pull it as a best-effort fallback.
 if ! modprobe mpt3sas 2>/dev/null; then
-  retry dnf -y install "kernel-modules-$(uname -r)" "kernel-modules-extra-$(uname -r)" \
-    || retry dnf -y install kernel-modules kernel-modules-extra || true
+  case "$distro" in
+    fedora)
+      retry pkg_install "kernel-modules-$(uname -r)" "kernel-modules-extra-$(uname -r)" \
+        || retry pkg_install kernel-modules kernel-modules-extra || true
+      ;;
+  esac
   depmod "$(uname -r)" || true
   modprobe mpt3sas || true
 fi
+
+# Add the runner user to container-runtime groups, but only those that actually
+# exist on this image/distro (a `docker` group, for example, only appears once
+# docker is installed). Skipping missing groups keeps user setup distro-agnostic
+# and avoids the cloud-init failure that listing a non-existent group causes.
+for grp in podman docker; do
+  if getent group "$grp" >/dev/null 2>&1; then
+    usermod -aG "$grp" "$vm_user"
+  fi
+done
+
+# Guarantee passwordless sudo for the runner user, independent of the base
+# image's cloud-init handling and of whether sudo shipped in the base image.
+install -d -m 0755 /etc/sudoers.d
+printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$vm_user" > "/etc/sudoers.d/90-${vm_user}"
+chmod 0440 "/etc/sudoers.d/90-${vm_user}"
+visudo -cf "/etc/sudoers.d/90-${vm_user}"
 
 cp /mnt/prepare-nvme-devices/prepare-nvme-devices.sh /prepare-nvme-devices.sh
 chmod +x /prepare-nvme-devices.sh

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm.yaml.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm.yaml.j2
@@ -4,6 +4,15 @@
 #
 # Authors: Dennis Maisenbacher (dennis.maisenbacher@wdc.com)
 
+{% set distro_defaults = {
+     'fedora':   {'root_device': 'LABEL=fedora', 'root_flags': 'subvol=root'},
+     'ubuntu':   {'root_device': '/dev/vda1', 'root_flags': ''},
+     'debian':   {'root_device': '/dev/vda1', 'root_flags': ''},
+     'opensuse': {'root_device': '/dev/vda2', 'root_flags': ''},
+   } %}
+{% set d = distro_defaults.get(distro | default('fedora', true), distro_defaults['fedora']) %}
+{% set root_device = root_device | default(d.root_device, true) %}
+{% set root_flags  = root_flags  | default(d.root_flags,  true) %}
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
@@ -37,7 +46,7 @@ spec:
               initrdPath: /boot/initramfs-{{ kernel_version }}.img
               kernelPath: /boot/vmlinux-{{ kernel_version }}
               imagePullPolicy: Always
-            kernelArgs: "loglevel=7 no_timer_check console=tty1 console=ttyS0,115200n8 systemd=off root=LABEL=fedora rootflags=subvol=root"
+            kernelArgs: "loglevel=7 no_timer_check console=tty1 console=ttyS0,115200n8 systemd=off root={{ root_device }}{% if root_flags %} rootflags={{ root_flags }}{% endif %}"
 {% endif %}
         devices:
           filesystems:
@@ -97,9 +106,10 @@ spec:
             userData: |
               #cloud-config
               users:
-                - name: fedora
+                - name: {{ vm_user | default('runner', true) }}
                   sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-                  groups: users, admin, docker, podman
+                  lock_passwd: true
+                  shell: /bin/bash
                   ssh_authorized_keys:
                     - {{ vm_ssh_authorized_keys }}
               runcmd:


### PR DESCRIPTION
Infer the distro from the container disk image and provision a dedicated passwordless-sudo runner user, so non-Fedora base images work too.