### PR TITLE
kpd: fix double-encoded config that crash-looped the daemon

### DIFF
--- a/playbooks/roles/k8s-install-kernel-patches-daemon/tasks/main.yaml
+++ b/playbooks/roles/k8s-install-kernel-patches-daemon/tasks/main.yaml
@@ -120,9 +120,9 @@
         name: kpd-config
         namespace: kernel-patches-daemon
       stringData:
-        kpd.json: "{{ kpd_config_json | to_json }}"
+        kpd.json: "{{ kpd_config_json }}"
         github-app-private-key.pem: "{{ kpd_github_app_private_key }}"
-        labels.json: "{{ kpd_labels_json | to_json }}"
+        labels.json: "{{ kpd_labels_json }}"
         template_base: "{{ kpd_template_base }}"
         template_success: "{{ kpd_template_success }}"
         template_failure: "{{ kpd_template_failure }}"


### PR DESCRIPTION
The kpd-config Secret rendered kpd.json and labels.json through the to_json filter, but both values are already JSON documents (kpd.json from the template, labels.json read from the kpd repo). to_json serialized them a second time, storing each as a quoted, escaped JSON string instead of a JSON object.