### PR TITLE
Speed up KubeVirt VM provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ storage-related kernel contribution is proposed, on real hardware.
 - [GitHub runner scale sets](#github-runner-scale-sets)
 - [GitLab runners](#gitlab-runners)
 - [Redeploying a new version](#redeploying-a-new-version)
+- [Running staging and prod side by side](#running-staging-and-prod-side-by-side)
 - [Operations and reference](#operations-and-reference)
   - [CI binary cache](#ci-binary-cache)
   - [Access logs via Grafana Loki](#access-logs-via-grafana-loki)
@@ -103,6 +104,12 @@ ansible-vault create secrets.enc
 Do not commit `secrets.enc`. Edit it later with `ansible-vault edit secrets.enc`;
 re-running the playbooks alone is not enough to change a secret value.
 
+The `kubeconfig` entry at the top of `variables.yaml` selects which cluster the
+playbooks and `redeploy.py` act on. It defaults to `~/.kube/config`; leave it as
+is for a single cluster. See
+[Connect kubectl to your workstation](#connect-kubectl-to-your-workstation) and
+[Running staging and prod side by side](#running-staging-and-prod-side-by-side).
+
 Copy the inventory template and fill in your node IPs:
 
 ```
@@ -160,6 +167,16 @@ Verify the connection:
 ```
 kubectl get nodes
 ```
+
+Every playbook and `redeploy.py` reads the `kubeconfig` variable from
+`variables.yaml` to decide which cluster to act on, and exports it as
+`KUBECONFIG` (for `kubectl`/`helm`/`virtctl`) and `K8S_AUTH_KUBECONFIG` (for the
+`kubernetes.core` Ansible modules) while they run. It defaults to the standard
+`~/.kube/config`, so a single-cluster setup needs no change. To drive more than
+one cluster from the same workstation, keep a separate kubeconfig per cluster
+(for example `~/.kube/config-prod` and `~/.kube/config-staging`) and set
+`kubeconfig` accordingly; see
+[Running staging and prod side by side](#running-staging-and-prod-side-by-side).
 
 ### Install the Kubernetes CI requirements
 
@@ -535,7 +552,9 @@ Also delete the runner in the GitLab UI (Settings -> CI/CD -> Runners).
 Once a cluster is up, `redeploy.py` rolls out a new version of this repository
 onto it. Run it from the repository root on the workstation, after pulling the
 latest changes and with `variables.yaml`, `secrets.enc` and `k8s-inventory.yaml`
-in place and `kubectl`/`helm` pointing at the target cluster. It performs two
+in place. It acts on the cluster named by the `kubeconfig` variable in
+`variables.yaml` (override with `--kubeconfig`), using it for its own
+`kubectl`/`helm` calls and forwarding it to the playbooks. It performs two
 steps:
 
 1. Re-runs `playbooks/install-k8s-requirements.yaml` to refresh the
@@ -585,6 +604,7 @@ python3 redeploy.py --from-log redeploy-scale-sets-<timestamp>.log
 
 Useful flags:
 ```
+--kubeconfig PATH           # target cluster's kubeconfig (default: from variables.yaml)
 --from-log FILE             # reload+redeploy the scale sets from a saved manifest
 --no-become-password        # nodes have passwordless sudo; do not prompt for it
 --vault-password-file FILE  # read the ansible-vault password from a file
@@ -592,6 +612,72 @@ Useful flags:
 --skip-install-requirements # only (terminate and) redeploy the runner scale sets
 --kinds github              # limit to github or gitlab (default: both)
 -y, --yes                   # do not ask for confirmation
+```
+
+## Running staging and prod side by side
+
+Because the target cluster is selected entirely by the `kubeconfig` variable,
+one workstation can drive several clusters at once by checking the repository
+out into one [git worktree](https://git-scm.com/docs/git-worktree) per cluster,
+each on its own branch with its own `kubeconfig`.
+
+Keep one kubeconfig file per cluster on the workstation, for example
+`~/.kube/config-prod` and `~/.kube/config-staging` (copy each from the
+respective cluster's `/etc/rancher/k3s/k3s.yaml`, as in
+[Connect kubectl to your workstation](#connect-kubectl-to-your-workstation)).
+
+Create a worktree and branch per cluster:
+```
+# from an existing checkout
+git worktree add ../blktests-ci-prod    -b prod
+git worktree add ../blktests-ci-staging -b staging
+```
+
+In each worktree, set `kubeconfig` in `variables.yaml` to that cluster's file
+and commit it on the worktree's branch (the `kubeconfig` line is the only
+intended difference between the branches):
+```
+# in ../blktests-ci-prod (branch: prod)
+kubeconfig: "~/.kube/config-prod"
+
+# in ../blktests-ci-staging (branch: staging)
+kubeconfig: "~/.kube/config-staging"
+```
+
+`secrets.enc` and `k8s-inventory.yaml` are git-ignored and therefore not shared
+between worktrees, so give each worktree its own copy of both, pointed at that
+cluster's nodes and secrets.
+
+The workstation-side scratch directory (`ansible_tmp_dir`, where the playbooks
+stage rendered manifests, downloaded release YAMLs and git checkouts) is derived
+from `kubeconfig`, so each cluster gets its own (e.g. `~/tmp-ansible-config-prod`
+vs `~/tmp-ansible-config-staging`). This keeps a staging run from reapplying a
+prod run's staged files, or leaking one cluster's Longhorn UI credentials to the
+other. Override `ansible_tmp_dir` in `variables.yaml` to pin an explicit path.
+
+From then on, every command run inside a worktree acts only on that worktree's
+cluster; the two never cross. Run the playbooks or `redeploy.py` from the
+matching directory:
+```
+cd ../blktests-ci-staging && python3 redeploy.py   # acts on staging
+cd ../blktests-ci-prod    && python3 redeploy.py   # acts on prod
+```
+
+To point a single command at another cluster without switching worktrees,
+override the kubeconfig explicitly (this wins over `variables.yaml`):
+```
+ansible-playbook -i k8s-inventory.yaml playbooks/install-k8s-requirements.yaml \
+  -e kubeconfig=~/.kube/config-staging --ask-vault-pass --ask-become-pass
+python3 redeploy.py --kubeconfig ~/.kube/config-staging
+```
+
+For ad-hoc `kubectl`/`helm`/`virtctl` against a specific cluster, point the tool
+at the file directly. `--kubeconfig` wins over the `KUBECONFIG` environment
+variable, which wins over the default `~/.kube/config`:
+```
+kubectl --kubeconfig ~/.kube/config-staging get nodes  # per command, via flag
+KUBECONFIG=~/.kube/config-staging kubectl get nodes     # per command, via env var
+export KUBECONFIG=~/.kube/config-staging                # for the whole shell session
 ```
 
 ## Operations and reference

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ storage-related kernel contribution is proposed, on real hardware.
   - [CI binary cache](#ci-binary-cache)
   - [Access logs via Grafana Loki](#access-logs-via-grafana-loki)
   - [Use the private container registry](#use-the-private-container-registry)
+  - [The test VM container disk](#the-test-vm-container-disk)
   - [Download a VM image](#download-a-vm-image)
   - [Add PCIe passthrough devices](#add-pcie-passthrough-devices)
   - [Access the Rook Ceph dashboard](#access-the-rook-ceph-dashboard)
@@ -765,6 +766,11 @@ spec:
       name: daemon-config
 EOF
 ```
+
+### The test VM container disk
+
+Manage the `kubevirt-runner` and `blktests` package bundles in
+[linux-nvme/ci-containers](https://github.com/linux-nvme/ci-containers).
 
 ### Download a VM image
 

--- a/playbooks/install-k8s-requirements.yaml
+++ b/playbooks/install-k8s-requirements.yaml
@@ -14,6 +14,9 @@
 - name: "Install required kubernetes componentes"
   hosts: localhost
   gather_facts: no
+  environment:
+    KUBECONFIG: "{{ kubeconfig | default('~/.kube/config', true) | expanduser }}"
+    K8S_AUTH_KUBECONFIG: "{{ kubeconfig | default('~/.kube/config', true) | expanduser }}"
   tasks:
     - include_vars: ../variables.yaml
     - include_vars: ../secrets.enc
@@ -23,9 +26,9 @@
         name: kubernetes
         state: present
 
-    - name: "Ensure ~/tmp-ansible exists for deployment files"
+    - name: "Ensure the scratch directory exists for deployment files"
       file:
-        path: "~/tmp-ansible"
+        path: "{{ ansible_tmp_dir }}"
         state: directory
 
     - name: "Wait until Kubernetes cluster is up and running again (in case of reboot)"
@@ -93,6 +96,9 @@
 - name: "Install kpd"
   hosts: localhost
   gather_facts: no
+  environment:
+    KUBECONFIG: "{{ kubeconfig | default('~/.kube/config', true) | expanduser }}"
+    K8S_AUTH_KUBECONFIG: "{{ kubeconfig | default('~/.kube/config', true) | expanduser }}"
   tasks:
     - include_vars: ../variables.yaml
     - include_vars: ../secrets.enc

--- a/playbooks/roles/k8s-install-gitlab-runner/tasks/main.yaml
+++ b/playbooks/roles/k8s-install-gitlab-runner/tasks/main.yaml
@@ -244,15 +244,15 @@
     state: present
     template: ../templates/kubevirt-actions-runner-rbac.yaml.j2
 
-- name: "Ensure ~/tmp-ansible exists"
+- name: "Ensure the scratch directory exists"
   file:
-    path: "~/tmp-ansible"
+    path: "{{ ansible_tmp_dir }}"
     state: directory
 
 - name: "Generate gitlab-runner-values.yaml from template"
   template:
     src: gitlab-runner-values.yaml.j2
-    dest: ~/tmp-ansible/gitlab-runner-values.yaml
+    dest: "{{ ansible_tmp_dir }}/gitlab-runner-values.yaml"
 
 - name: "Add the GitLab Helm repository"
   kubernetes.core.helm_repository:
@@ -266,4 +266,4 @@
     create_namespace: true
     chart_ref: gitlab/gitlab-runner
     chart_version: "{{ gitlab_runner_version }}"
-    values_files: "{{ lookup('ansible.builtin.env', 'HOME') }}/tmp-ansible/gitlab-runner-values.yaml"
+    values_files: "{{ ansible_tmp_dir | expanduser }}/gitlab-runner-values.yaml"

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/tasks/main.yaml
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/tasks/main.yaml
@@ -323,15 +323,15 @@
   set_fact:
     pci_device_labels: "{{ cluster_nodes.resources | map(attribute='status.allocatable', default={}) | map('dict2items') | flatten | selectattr('key', 'in', permitted_pci_devices) | selectattr('value', '!=', '0') | map(attribute='key') | map('regex_replace', '^devices.kubevirt.io/', '') | unique | list }}"
 
-- name: "Ensure ~/tmp-ansible exists"
+- name: "Ensure the scratch directory exists"
   file:
-    path: "~/tmp-ansible"
+    path: "{{ ansible_tmp_dir }}"
     state: directory
 
 - name: Generate arc-vm-scale-set-values.yaml from template
   template:
     src: arc-vm-scale-set-values.yaml.j2
-    dest: ~/tmp-ansible/arc-vm-scale-set-values.yaml
+    dest: "{{ ansible_tmp_dir }}/arc-vm-scale-set-values.yaml"
   vars:
     github_config_secret: "github-config-secret"
 
@@ -347,4 +347,4 @@
     create_namespace: true
     chart_version: "{{ gha_rss_version }}"
     chart_ref: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
-    values_files: "{{ lookup('ansible.builtin.env', 'HOME') }}/tmp-ansible/arc-vm-scale-set-values.yaml"
+    values_files: "{{ ansible_tmp_dir | expanduser }}/arc-vm-scale-set-values.yaml"

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2
@@ -132,7 +132,19 @@ retry pkg_install sudo podman jq nvme-cli "$sg3_utils_pkg" lsscsi
 # A passed-through SAS HBA needs the mpt3sas driver. It is usually built into or
 # already shipped with the distro kernel; on Fedora the driver lives in the
 # kernel-modules(-extra) package, so pull it as a best-effort fallback.
-if ! modprobe mpt3sas 2>/dev/null; then
+sas_hba_attached() {
+  local vendor_file
+  for vendor_file in /sys/bus/pci/devices/*/vendor; do
+    # 0x1000 is LSI Logic / Broadcom, the vendor of the permitted SAS34xx HBAs.
+    [ -r "$vendor_file" ] || continue
+    if [ "$(cat "$vendor_file")" = "0x1000" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if sas_hba_attached && ! modprobe mpt3sas 2>/dev/null; then
   case "$distro" in
     fedora)
       retry pkg_install "kernel-modules-$(uname -r)" "kernel-modules-extra-$(uname -r)" \

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2
@@ -120,7 +120,8 @@ mount -t virtiofs prepare-nvme-devices /mnt/prepare-nvme-devices
 {% if kernel_version is defined and kernel_version %}
 mkdir -p /mnt/kernel-modules-disk
 mount /dev/sr0 /mnt/kernel-modules-disk
-tar -xvf /mnt/kernel-modules-disk/kernel_m.tgz --directory /usr/lib/modules/
+# Avoid flooding the serial console with module names.
+tar -xf /mnt/kernel-modules-disk/kernel_m.tgz --directory /usr/lib/modules/
 # Refresh modules.dep so modprobe can resolve the just-extracted modules. The
 # tarball unpacks under the kernel's real release (e.g. 7.2.0-rc1), which is
 # what uname -r reports for the booted kernel; the "{{ kernel_version }}" build

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm-init.sh.j2
@@ -35,6 +35,7 @@ vm_user="{{ vm_user | default('runner', true) }}"
 case "$distro" in
   ubuntu|debian)
     pkg_install() { apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"; }
+    pkg_present() { dpkg -s "$1" >/dev/null 2>&1; }
     ca_anchor_dir="/usr/local/share/ca-certificates"
     ca_cert_ext="crt"
     ca_update_cmd="update-ca-certificates"
@@ -42,6 +43,7 @@ case "$distro" in
     ;;
   opensuse)
     pkg_install() { zypper --non-interactive install "$@"; }
+    pkg_present() { rpm -q "$1" >/dev/null 2>&1; }
     ca_anchor_dir="/etc/pki/trust/anchors"
     ca_cert_ext="pem"
     ca_update_cmd="update-ca-certificates"
@@ -50,6 +52,7 @@ case "$distro" in
   *)
     # fedora and other dnf-based (rhel/centos/almalinux) images
     pkg_install() { dnf install -y "$@"; }
+    pkg_present() { rpm -q "$1" >/dev/null 2>&1; }
     ca_anchor_dir="/etc/pki/ca-trust/source/anchors"
     ca_cert_ext="pem"
     ca_update_cmd="update-ca-trust"
@@ -127,7 +130,17 @@ depmod "$(uname -r)"
 modprobe tun
 loginctl enable-linger "$vm_user"
 
-retry pkg_install sudo podman jq nvme-cli "$sg3_utils_pkg" lsscsi
+# Install only tooling missing from the base image.
+# Test the joined expansion because shell array-length syntax conflicts with Jinja.
+missing_pkgs=()
+for pkg in sudo podman jq nvme-cli "$sg3_utils_pkg" lsscsi; do
+  pkg_present "$pkg" || missing_pkgs+=("$pkg")
+done
+if [ -n "${missing_pkgs[*]}" ]; then
+  retry pkg_install "${missing_pkgs[@]}"
+else
+  echo "runner tooling already present in the image; skipping package install"
+fi
 
 # A passed-through SAS HBA needs the mpt3sas driver. It is usually built into or
 # already shipped with the distro kernel; on Fedora the driver lives in the

--- a/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm.yaml.j2
+++ b/playbooks/roles/k8s-install-kubevirt-actions-runner-controller/templates/vm.yaml.j2
@@ -87,7 +87,8 @@ spec:
       volumes:
         - name: containerdisk
           containerDisk:
-            image: {{ container_disk_image | default('quay.io/containerdisks/fedora:42', true) }}
+            image: {{ container_disk_image | default('ghcr.io/linux-nvme/blktests-fedora-containerdisk:latest', true) }}
+            imagePullPolicy: Always
 {% if kernel_version is defined and kernel_version %}
         - name: kernel-modules
           containerDisk:

--- a/playbooks/roles/k8s-install-kubevirt/tasks/main.yaml
+++ b/playbooks/roles/k8s-install-kubevirt/tasks/main.yaml
@@ -11,25 +11,25 @@
     name: kubernetes
     state: present
 
-- name: "Ensure ~/tmp-ansible exists for deployment files"
+- name: "Ensure the scratch directory exists for deployment files"
   file:
-    path: "~/tmp-ansible"
+    path: "{{ ansible_tmp_dir }}"
     state: directory
 
 - name: Download kubevirt deployment files
   shell: |
-    wget -P ~/tmp-ansible https://github.com/kubevirt/kubevirt/releases/download/{{ kubevirt_version }}/kubevirt-operator.yaml
-    wget -P ~/tmp-ansible https://github.com/kubevirt/kubevirt/releases/download/{{ kubevirt_version }}/kubevirt-cr.yaml
+    wget -P {{ ansible_tmp_dir | expanduser | quote }} https://github.com/kubevirt/kubevirt/releases/download/{{ kubevirt_version }}/kubevirt-operator.yaml
+    wget -P {{ ansible_tmp_dir | expanduser | quote }} https://github.com/kubevirt/kubevirt/releases/download/{{ kubevirt_version }}/kubevirt-cr.yaml
 
 - name: "Install KubeVirt operator"
   kubernetes.core.k8s:
     state: present
-    src: ~/tmp-ansible/kubevirt-operator.yaml
+    src: "{{ ansible_tmp_dir }}/kubevirt-operator.yaml"
 
 - name: "Install KubeVirt custom resource"
   kubernetes.core.k8s:
     state: present
-    src: ~/tmp-ansible/kubevirt-cr.yaml
+    src: "{{ ansible_tmp_dir }}/kubevirt-cr.yaml"
 
 - name: "Install Virtctl"
   become: yes
@@ -41,20 +41,20 @@
   shell: |
     kubectl -n kubevirt wait kv kubevirt --for condition=Available --timeout=600s
 
-- name: "Ensure ~/tmp-ansible exists for KubeVirt configuration"
+- name: "Ensure the scratch directory exists for KubeVirt configuration"
   file:
-    path: "~/tmp-ansible"
+    path: "{{ ansible_tmp_dir }}"
     state: directory
 
 - name: "Copy KubeVirt config deployment file"
   copy:
     src: ./kubevirt-config.yaml
-    dest: ~/tmp-ansible/kubevirt-config.yaml
+    dest: "{{ ansible_tmp_dir }}/kubevirt-config.yaml"
 
 - name: "Enable required KubeVirt config features"
   kubernetes.core.k8s:
     state: present
-    src: ~/tmp-ansible/kubevirt-config.yaml
+    src: "{{ ansible_tmp_dir }}/kubevirt-config.yaml"
 
 - name: "Wait for KubeVirt pods to become ready"
   shell: "kubectl wait --namespace=kubevirt --for=condition=Ready pod --all --timeout=1200s"
@@ -65,15 +65,15 @@
 # Install KubeVirt CDI
 - name: Download kubevirt CDI deployment files
   shell: |
-    wget -P ~/tmp-ansible https://github.com/kubevirt/containerized-data-importer/releases/download/{{ kubevirt_cri_version }}/cdi-operator.yaml
-    wget -P ~/tmp-ansible https://github.com/kubevirt/containerized-data-importer/releases/download/{{ kubevirt_cri_version }}/cdi-cr.yaml
+    wget -P {{ ansible_tmp_dir | expanduser | quote }} https://github.com/kubevirt/containerized-data-importer/releases/download/{{ kubevirt_cri_version }}/cdi-operator.yaml
+    wget -P {{ ansible_tmp_dir | expanduser | quote }} https://github.com/kubevirt/containerized-data-importer/releases/download/{{ kubevirt_cri_version }}/cdi-cr.yaml
 
 - name: "Install KubeVirt CDI operator for VM image repository"
   kubernetes.core.k8s:
     state: present
-    src: ~/tmp-ansible/cdi-operator.yaml
+    src: "{{ ansible_tmp_dir }}/cdi-operator.yaml"
 
 - name: "Install KubeVirt CDI custom resource for VM image repository"
   kubernetes.core.k8s:
     state: present
-    src: ~/tmp-ansible/cdi-cr.yaml
+    src: "{{ ansible_tmp_dir }}/cdi-cr.yaml"

--- a/playbooks/roles/k8s-install-longhorn/tasks/main.yaml
+++ b/playbooks/roles/k8s-install-longhorn/tasks/main.yaml
@@ -31,22 +31,22 @@
 
 #https://longhorn.io/docs/1.8.0/deploy/accessing-the-ui/longhorn-ingress/
 
-- name: "Ensure ~/tmp-ansible exists for configuring Longhorn UI access"
+- name: "Ensure the scratch directory exists for configuring Longhorn UI access"
   file:
-    path: "~/tmp-ansible"
+    path: "{{ ansible_tmp_dir }}"
     state: directory
 
 - name: "Check if auth file exists"
   stat:
-    path: "~/tmp-ansible/auth"
+    path: "{{ ansible_tmp_dir }}/auth"
   register: auth_file
 
 - name: "Create auth file"
-  shell: "echo {{ longhorn_ui_auth_user }}:$(openssl passwd -apr1 {{ longhorn_ui_auth_password }}) | xargs > ~/tmp-ansible/auth"
+  shell: "echo {{ longhorn_ui_auth_user }}:$(openssl passwd -apr1 {{ longhorn_ui_auth_password }}) | xargs > {{ (ansible_tmp_dir ~ '/auth') | expanduser | quote }}"
   when: not auth_file.stat.exists
 
 - name: "Get content of auth file"
-  shell: "cat ~/tmp-ansible/auth | base64"
+  shell: "cat {{ (ansible_tmp_dir ~ '/auth') | expanduser | quote }} | base64"
   register: auth_contents
 
 - name: "Create Longhorn basic auth secret"
@@ -65,13 +65,13 @@
 - name: "Copy Longhorn ingress deployment file"
   copy:
     src: ./longhorn-ingress.yaml
-    dest: ~/tmp-ansible/longhorn-ingress.yaml
+    dest: "{{ ansible_tmp_dir }}/longhorn-ingress.yaml"
 
 - name: "Apply Longhorn ingress deployment"
   kubernetes.core.k8s:
     state: present
     namespace: longhorn-system
-    src: ~/tmp-ansible/longhorn-ingress.yaml
+    src: "{{ ansible_tmp_dir }}/longhorn-ingress.yaml"
 
 # Enable snapshot support
 # https://longhorn.io/docs/1.8.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support/
@@ -79,7 +79,7 @@
 - name: "Git checkout"
   ansible.builtin.git:
     repo: 'https://github.com/kubernetes-csi/external-snapshotter.git'
-    dest: ~/tmp-ansible/external-snapshotter
+    dest: "{{ ansible_tmp_dir }}/external-snapshotter"
     version: "{{ longhorn_external_snapshotter_version }}"
 
 - name: "Apply external snapshotter crd"
@@ -88,7 +88,7 @@
     src: "{{ item }}"
   loop: >-
     {{
-      lookup('fileglob', '~/tmp-ansible/external-snapshotter/client/config/crd/*snapshot*.y*ml', wantlist=True)
+      lookup('fileglob', ansible_tmp_dir ~ '/external-snapshotter/client/config/crd/*snapshot*.y*ml', wantlist=True)
       | map('expanduser') | list
     }}
 
@@ -99,7 +99,7 @@
     src: "{{ item }}"
   loop: >-
     {{
-      lookup('fileglob', '~/tmp-ansible/external-snapshotter/deploy/kubernetes/snapshot-controller/*snapshot-controller.y*ml', wantlist=True)
+      lookup('fileglob', ansible_tmp_dir ~ '/external-snapshotter/deploy/kubernetes/snapshot-controller/*snapshot-controller.y*ml', wantlist=True)
       | map('expanduser') | list
     }}
 

--- a/playbooks/roles/k8s-install-rook-ceph/tasks/main.yaml
+++ b/playbooks/roles/k8s-install-rook-ceph/tasks/main.yaml
@@ -6,15 +6,15 @@
 
 - include_vars: ../../../../variables.yaml
 
-- name: "Ensure ~/tmp-ansible exists for rook-ceph deployment files"
+- name: "Ensure the scratch directory exists for rook-ceph deployment files"
   file:
-    path: "~/tmp-ansible"
+    path: "{{ ansible_tmp_dir }}"
     state: directory
 
 - name: "Clone rook repository"
   ansible.builtin.git:
     repo: "{{ rook_ceph_repo }}"
-    dest: "~/tmp-ansible/rook"
+    dest: "{{ ansible_tmp_dir }}/rook"
     version: "{{ rook_ceph_version }}"
     single_branch: true
 
@@ -24,14 +24,14 @@
   shell: |
     kubectl create -f crds.yaml -f common.yaml -f operator.yaml
   args:
-    chdir: ~/tmp-ansible/rook/deploy/examples
+    chdir: "{{ ansible_tmp_dir }}/rook/deploy/examples"
 
 - name: "Wait for rook-ceph pods to become ready"
   shell: "kubectl wait --namespace=rook-ceph --for=condition=Ready pod --all --timeout=2000s"
 
 - name: "Adjust device names that are allowed to be deployed in the cluster -> All nvme devices that are not unbound by default are allowed to be used"
   ansible.builtin.lineinfile:
-    path: ~/tmp-ansible/rook/deploy/examples/cluster.yaml
+    path: "{{ ansible_tmp_dir }}/rook/deploy/examples/cluster.yaml"
     regexp: '^(\s*)#deviceFilter:'
     line: '    deviceFilter: ^nvme.*'
     state: present
@@ -40,13 +40,13 @@
   shell: |
     kubectl create -f cluster.yaml
   args:
-    chdir: ~/tmp-ansible/rook/deploy/examples
+    chdir: "{{ ansible_tmp_dir }}/rook/deploy/examples"
 
 - name: "Deploy ceph rbd (block) storage class"
   shell: |
     kubectl create -f storageclass.yaml
   args:
-    chdir: ~/tmp-ansible/rook/deploy/examples/csi/rbd
+    chdir: "{{ ansible_tmp_dir }}/rook/deploy/examples/csi/rbd"
 
 - name: "Set rook-ceph-block as default storage-class"
   shell: |
@@ -56,13 +56,13 @@
   shell: |
     kubectl create -f snapshotclass.yaml
   args:
-    chdir: ~/tmp-ansible/rook/deploy/examples/csi/rbd
+    chdir: "{{ ansible_tmp_dir }}/rook/deploy/examples/csi/rbd"
 
 - name: "Deploy ceph-fs"
   shell: |
     kubectl create -f filesystem.yaml
   args:
-    chdir: ~/tmp-ansible/rook/deploy/examples
+    chdir: "{{ ansible_tmp_dir }}/rook/deploy/examples"
 
 - name: "Wait for rook-ceph-mds pods to become ready"
   shell: "kubectl wait --namespace=rook-ceph --for=condition=Ready pod -l app=rook-ceph-mds --timeout=2000s"
@@ -71,7 +71,7 @@
   shell: |
     kubectl create -f storageclass.yaml
   args:
-    chdir: ~/tmp-ansible/rook/deploy/examples/csi/cephfs
+    chdir: "{{ ansible_tmp_dir }}/rook/deploy/examples/csi/cephfs"
 
 - name: "Add Prometheus Community helm repo"
   kubernetes.core.helm_repository:
@@ -93,7 +93,7 @@
   shell: |
     kubectl create -f service-monitor.yaml -f exporter-service-monitor.yaml -f prometheus.yaml -f prometheus-service.yaml
   args:
-    chdir: ~/tmp-ansible/rook/deploy/examples/monitoring
+    chdir: "{{ ansible_tmp_dir }}/rook/deploy/examples/monitoring"
 
 - name: "Wait for rook-ceph prometheus pods to become ready"
   shell: "kubectl wait --namespace=rook-ceph --for=condition=Ready pod prometheus-rook-prometheus-0 --timeout=2000s"
@@ -102,7 +102,7 @@
   shell: |
     kubectl create -f rbac.yaml -f localrules.yaml
   args:
-    chdir: ~/tmp-ansible/rook/deploy/examples/monitoring
+    chdir: "{{ ansible_tmp_dir }}/rook/deploy/examples/monitoring"
 
 - name: "Patch CephCluster to enable monitoring"
   shell: |

--- a/playbooks/roles/kernel-builder-k8s-job/templates/build-kernel.sh
+++ b/playbooks/roles/kernel-builder-k8s-job/templates/build-kernel.sh
@@ -92,7 +92,52 @@ yes "" | make olddefconfig
 ./scripts/config --disable CONFIG_CXL_REGION
 ./scripts/config --disable CONFIG_CXL_PMU
 ./scripts/config --disable CONFIG_DEV_DAX_CXL
+
+# Drop hardware classes unused by storage-test VMs; retain virtual displays.
+./scripts/config --disable CONFIG_DRM_AMDGPU
+./scripts/config --disable CONFIG_DRM_I915
+./scripts/config --disable CONFIG_DRM_XE
+./scripts/config --disable CONFIG_DRM_NOUVEAU
+./scripts/config --disable CONFIG_DRM_RADEON
+./scripts/config --disable CONFIG_DRM_AMD_DC
+./scripts/config --disable CONFIG_DRM_GMA500
+./scripts/config --disable CONFIG_DRM_AST
+./scripts/config --disable CONFIG_DRM_QXL
+# Wireless.
+./scripts/config --disable CONFIG_WLAN
+./scripts/config --disable CONFIG_MAC80211
+./scripts/config --disable CONFIG_CFG80211
+./scripts/config --disable CONFIG_RFKILL
+# Sound.
+./scripts/config --disable CONFIG_SOUND
+./scripts/config --disable CONFIG_SND
+
 yes "" | make olddefconfig
+
+# Fail before publishing a kernel that cannot boot the test VM.
+required_configs="
+CONFIG_VIRTIO
+CONFIG_VIRTIO_PCI
+CONFIG_VIRTIO_BLK
+CONFIG_VIRTIO_NET
+CONFIG_VIRTIO_FS
+CONFIG_FUSE_FS
+CONFIG_BTRFS_FS
+CONFIG_ISO9660_FS
+CONFIG_BLK_DEV_NULL_BLK
+CONFIG_BLK_DEV_ZONED
+CONFIG_IKCONFIG_PROC
+CONFIG_KASAN
+CONFIG_PROVE_LOCKING
+"
+missing_configs=""
+for sym in $required_configs; do
+    grep -qE "^${sym}=(y|m)\$" .config || missing_configs="${missing_configs} ${sym}"
+done
+if [ -n "$missing_configs" ]; then
+    echo "error: required kernel options are not enabled after config trim:${missing_configs}" >&2
+    exit 1
+fi
 
 #initramfs creation inspired by https://github.com/floatious/boot-scripts/blob/master/old/boot
 

--- a/playbooks/setup-github-runner-scale-set.yaml
+++ b/playbooks/setup-github-runner-scale-set.yaml
@@ -8,6 +8,9 @@
 - name: "Create a kubevirt-actions-runner scale set to spawn KubeVirt VMs on demand from a GitHub workflow"
   hosts: localhost
   gather_facts: no
+  environment:
+    KUBECONFIG: "{{ kubeconfig | default('~/.kube/config', true) | expanduser }}"
+    K8S_AUTH_KUBECONFIG: "{{ kubeconfig | default('~/.kube/config', true) | expanduser }}"
   vars_prompt:
     - name: runner_set_name
       prompt: Suffix of the GitHub runner set
@@ -32,6 +35,8 @@
       default: ""
       private: false
   tasks:
+    - include_vars: ../variables.yaml
+
     - name: "Install the kernel builder cron job for building nightly kernels"
       include_role:
         name: kernel-builder-k8s-job

--- a/playbooks/setup-gitlab-runner-scale-set.yaml
+++ b/playbooks/setup-gitlab-runner-scale-set.yaml
@@ -8,6 +8,9 @@
 - name: "Deploy a GitLab Runner (Kubernetes executor) that spawns KubeVirt VMs on demand from a GitLab CI/CD pipeline"
   hosts: localhost
   gather_facts: no
+  environment:
+    KUBECONFIG: "{{ kubeconfig | default('~/.kube/config', true) | expanduser }}"
+    K8S_AUTH_KUBECONFIG: "{{ kubeconfig | default('~/.kube/config', true) | expanduser }}"
   vars_prompt:
     - name: runner_set_name
       prompt: Suffix of the GitLab runner deployment (namespace gl-runner-<suffix>)
@@ -20,6 +23,8 @@
       default: ""
       private: false
   tasks:
+    - include_vars: ../variables.yaml
+
     - name: "Install the kernel builder cron job for building nightly kernels"
       include_role:
         name: kernel-builder-k8s-job

--- a/redeploy.py
+++ b/redeploy.py
@@ -9,8 +9,11 @@
 
 Run this from a workstation that has pulled the latest changes and has the
 Ansible variables and secrets in place (``variables.yaml``, ``secrets.enc`` and
-``k8s-inventory.yaml``), with ``kubectl``/``helm`` pointed at the target
-cluster. It performs a redeploy in two steps:
+``k8s-inventory.yaml``). The target cluster is chosen by the ``kubeconfig`` value
+in ``variables.yaml`` (or ``--kubeconfig``); that path is exported for this
+script's own ``kubectl``/``helm`` calls and for the ansible-playbook runs, so a
+staging and a prod worktree each drive their own cluster. It performs a redeploy
+in two steps:
 
   1. Re-run ``playbooks/install-k8s-requirements.yaml`` to refresh the
      cluster-wide components (longhorn, KubeVirt, registry, logging, mitmproxy,
@@ -67,6 +70,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent
 INVENTORY = REPO_ROOT / "k8s-inventory.yaml"
+VARIABLES = REPO_ROOT / "variables.yaml"
 INSTALL_PLAYBOOK = REPO_ROOT / "playbooks" / "install-k8s-requirements.yaml"
 GITHUB_PLAYBOOK = REPO_ROOT / "playbooks" / "setup-github-runner-scale-set.yaml"
 GITLAB_PLAYBOOK = REPO_ROOT / "playbooks" / "setup-gitlab-runner-scale-set.yaml"
@@ -173,6 +177,63 @@ def preflight() -> None:
             raise RedeployError(f"expected repo file is missing: {path}")
 
 
+# --------------------------------------------------------------------------- #
+# Kubeconfig
+# --------------------------------------------------------------------------- #
+
+_VARIABLES_KUBECONFIG_RE = re.compile(
+    r'''(?m)^kubeconfig:\s*["']?([^"'#\n]+?)["']?\s*(?:#.*)?$'''
+)
+
+
+def _kubeconfig_from_variables() -> str | None:
+    """Best-effort read of the ``kubeconfig`` value from variables.yaml.
+
+    The playbooks read the same key, so redeploy must resolve it identically to
+    keep its own kubectl/helm calls pointed at the cluster the playbooks target.
+    Prefers PyYAML (a hard Ansible dependency) and falls back to a line scan so a
+    missing interpreter still works. Blank/whitespace-only values are treated as
+    unset, so the caller falls back to the default.
+    """
+    if not VARIABLES.exists():
+        return None
+    text = VARIABLES.read_text()
+    try:
+        import yaml
+    except ImportError:
+        yaml = None
+    if yaml is not None:
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError:
+            data = None
+        if isinstance(data, dict):
+            value = str(data.get("kubeconfig") or "").strip()
+            if value:
+                return value
+    match = _VARIABLES_KUBECONFIG_RE.search(text)
+    if match and match.group(1).strip():
+        return match.group(1).strip()
+    return None
+
+
+def resolve_kubeconfig(cli_value: str | None) -> tuple[str, str]:
+    """Resolve the kubeconfig path used for every cluster call.
+
+    Precedence: ``--kubeconfig`` > variables.yaml ``kubeconfig`` > ~/.kube/config.
+    Returns (absolute_path, source) where source is one of ``cli``, ``variables``
+    or ``default``. When the source is ``cli`` the value must also be forwarded to
+    the playbooks as an extra-var, because their play-level environment otherwise
+    re-derives KUBECONFIG from variables.yaml and would ignore the override.
+    """
+    if cli_value:
+        return os.path.abspath(os.path.expanduser(cli_value)), "cli"
+    from_vars = _kubeconfig_from_variables()
+    if from_vars:
+        return os.path.abspath(os.path.expanduser(from_vars)), "variables"
+    return os.path.abspath(os.path.expanduser("~/.kube/config")), "default"
+
+
 def ssh_agent_has_keys() -> tuple[bool, str]:
     """Best-effort check that the ssh-agent holds a usable key.
 
@@ -251,18 +312,15 @@ def discover(kinds: list[str]) -> list[RunnerScaleSet]:
 
 _OVERVIEW_HEADER_RE = re.compile(r"^\[(github|gitlab)\]\s+(.+?)\s*$")
 _OVERVIEW_FIELD_RE = re.compile(r"^(url|namespace|release):\s*(.+?)\s*$")
+_OVERVIEW_KUBECONFIG_RE = re.compile(r"^Target cluster kubeconfig:\s+(.+?)\s+\(from .+\)$")
 
 
-def parse_overview(path: Path) -> list[RunnerScaleSet]:
-    """Load runner scale sets back from an overview manifest written earlier.
-
-    Reads the per-set ``[kind] name`` blocks and their url/namespace/release
-    fields; the human-readable preamble and ``redeploy:`` command lines are
-    ignored (the recreate command is rebuilt from the fields).
-    """
+def parse_overview(path: Path) -> tuple[list[RunnerScaleSet], str | None]:
+    """Load runner scale sets and their target kubeconfig from an overview."""
     if not path.exists():
         raise RedeployError(f"overview log not found: {path}")
     sets: list[RunnerScaleSet] = []
+    kubeconfig: str | None = None
     current: dict[str, str] | None = None
 
     def flush() -> None:
@@ -284,6 +342,10 @@ def parse_overview(path: Path) -> list[RunnerScaleSet]:
 
     for raw in path.read_text().splitlines():
         stripped = raw.strip()
+        target = _OVERVIEW_KUBECONFIG_RE.match(stripped)
+        if target:
+            kubeconfig = target.group(1)
+            continue
         header = _OVERVIEW_HEADER_RE.match(stripped)
         if header:
             flush()
@@ -298,7 +360,7 @@ def parse_overview(path: Path) -> list[RunnerScaleSet]:
     if not sets:
         raise RedeployError(f"no runner scale sets found in {path}")
     sets.sort(key=lambda s: (s.kind, s.name))
-    return sets
+    return sets, kubeconfig
 
 
 # --------------------------------------------------------------------------- #
@@ -321,13 +383,15 @@ def terminate(scale_set: RunnerScaleSet, *, dry_run: bool) -> None:
             dry_run=dry_run, check=False)
 
 
-def recreate_argv(scale_set: RunnerScaleSet, *, relative: bool = False) -> list[str]:
+def recreate_argv(scale_set: RunnerScaleSet, *, relative: bool = False,
+                  kubeconfig: str | None = None) -> list[str]:
     """Build the ansible-playbook argv that recreates one scale set.
 
     Auth extra-vars are intentionally empty so the setup playbook reuses the
     existing secret instead of prompting. With ``relative=True`` the inventory
     and playbook paths are relative to the repo root, for a copy-pasteable
-    command in the overview manifest.
+    command in the overview manifest. ``kubeconfig`` is only passed when it was
+    overridden on the CLI; otherwise the playbook reads it from variables.yaml.
     """
     if scale_set.kind == GITHUB:
         extra_vars = {
@@ -344,6 +408,8 @@ def recreate_argv(scale_set: RunnerScaleSet, *, relative: bool = False) -> list[
             "gitlab_url": scale_set.config_url,
             "gitlab_runner_token": "",
         }
+    if kubeconfig:
+        extra_vars["kubeconfig"] = kubeconfig
     inventory = INVENTORY
     playbook = KIND_META[scale_set.kind]["playbook"]
     if relative:
@@ -353,10 +419,10 @@ def recreate_argv(scale_set: RunnerScaleSet, *, relative: bool = False) -> list[
             "-e", json.dumps(extra_vars)]
 
 
-def recreate(scale_set: RunnerScaleSet, *, dry_run: bool) -> None:
+def recreate(scale_set: RunnerScaleSet, *, dry_run: bool, kubeconfig: str | None = None) -> None:
     """Recreate one scale set via its setup playbook, reusing the auth secret."""
     _log(f"  -> redeploying {scale_set.label} ({scale_set.config_url})")
-    run(recreate_argv(scale_set), dry_run=dry_run)
+    run(recreate_argv(scale_set, kubeconfig=kubeconfig), dry_run=dry_run)
 
 
 # --------------------------------------------------------------------------- #
@@ -377,10 +443,13 @@ def _password_file(contents: str, registry: list[str]) -> str:
     return path
 
 
-def install_requirements(vault_pw: str | None, become_pw: str | None, *, dry_run: bool) -> None:
+def install_requirements(vault_pw: str | None, become_pw: str | None, *, dry_run: bool,
+                         kubeconfig: str | None = None) -> None:
     """Re-run install-k8s-requirements.yaml (reads secrets.enc, uses become)."""
     _log("  -> re-running install-k8s-requirements.yaml")
     cmd = ["ansible-playbook", "-i", str(INVENTORY), str(INSTALL_PLAYBOOK)]
+    if kubeconfig:
+        cmd += ["-e", json.dumps({"kubeconfig": kubeconfig})]
     tmp_files: list[str] = []
     try:
         if dry_run:
@@ -407,9 +476,14 @@ def install_requirements(vault_pw: str | None, become_pw: str | None, *, dry_run
 # Overview manifest
 # --------------------------------------------------------------------------- #
 
-def build_overview(scale_sets: list[RunnerScaleSet], *, reloaded_from: Path | None = None) -> str:
+def build_overview(scale_sets: list[RunnerScaleSet], *, reloaded_from: Path | None = None,
+                   kubeconfig: str | None = None, kubeconfig_is_override: bool = False) -> str:
     """Render the recovery manifest: every scale set and how to redeploy it by
     hand. The manifest can be fed back to the script with --from-log."""
+    # Only forward the kubeconfig to the by-hand commands when it was overridden
+    # on the CLI; otherwise those commands read it from variables.yaml like a
+    # normal run from this worktree.
+    cmd_kubeconfig = kubeconfig if kubeconfig_is_override else None
     line = "=" * 74
     out = [
         line,
@@ -417,6 +491,10 @@ def build_overview(scale_sets: list[RunnerScaleSet], *, reloaded_from: Path | No
         f"Captured: {datetime.now().isoformat(timespec='seconds')} (before any changes)",
         line,
     ]
+    if kubeconfig is not None:
+        origin = "--kubeconfig override" if kubeconfig_is_override else "variables.yaml"
+        out.append(f"Target cluster kubeconfig: {kubeconfig} (from {origin})")
+        out.append(line)
     if reloaded_from is not None:
         out.append(f"Loaded from {reloaded_from}; these runner scale sets are being redeployed.")
     else:
@@ -425,11 +503,16 @@ def build_overview(scale_sets: list[RunnerScaleSet], *, reloaded_from: Path | No
             "redeploy fails hard, redeploy any of them by hand from the repo root with",
             "the command shown, or feed this whole file back with --from-log.",
         ]
+    install_cmd = [
+        "  ansible-playbook -i k8s-inventory.yaml playbooks/install-k8s-requirements.yaml \\",
+    ]
+    if cmd_kubeconfig:
+        install_cmd.append(f"    -e kubeconfig={shlex.quote(cmd_kubeconfig)} \\")
+    install_cmd.append("    --ask-vault-pass --ask-become-pass")
     out += [
         "Auth is intentionally empty so the existing secret is reused.",
         "install-k8s-requirements.yaml is re-run separately with:",
-        "  ansible-playbook -i k8s-inventory.yaml playbooks/install-k8s-requirements.yaml \\",
-        "    --ask-vault-pass --ask-become-pass",
+        *install_cmd,
         line,
     ]
     if not scale_sets:
@@ -440,7 +523,7 @@ def build_overview(scale_sets: list[RunnerScaleSet], *, reloaded_from: Path | No
             f"    url:       {s.config_url}",
             f"    namespace: {s.namespace}",
             f"    release:   {s.release}",
-            f"    redeploy:  {shlex.join(recreate_argv(s, relative=True))}",
+            f"    redeploy:  {shlex.join(recreate_argv(s, relative=True, kubeconfig=cmd_kubeconfig))}",
             "",
         ]
     out.append(line)
@@ -448,10 +531,12 @@ def build_overview(scale_sets: list[RunnerScaleSet], *, reloaded_from: Path | No
 
 
 def emit_overview(scale_sets: list[RunnerScaleSet], overview_file: Path, *,
-                  dry_run: bool, reloaded_from: Path | None = None) -> None:
+                  dry_run: bool, reloaded_from: Path | None = None,
+                  kubeconfig: str | None = None, kubeconfig_is_override: bool = False) -> None:
     """Print the overview and, on a real run, persist it to the manifest file
     without ever overwriting an existing one."""
-    overview = build_overview(scale_sets, reloaded_from=reloaded_from)
+    overview = build_overview(scale_sets, reloaded_from=reloaded_from,
+                              kubeconfig=kubeconfig, kubeconfig_is_override=kubeconfig_is_override)
     _log(overview)
     if dry_run:
         _log(f"(dry-run: overview not written; a real run writes it to {overview_file})")
@@ -528,6 +613,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Comma-separated runner kinds to redeploy (github, gitlab).",
     )
     parser.add_argument(
+        "--kubeconfig", metavar="PATH", default=None,
+        help="Kubeconfig for the target cluster, used for this script's own "
+             "kubectl/helm calls and forwarded to the playbooks. Overrides the "
+             "'kubeconfig' value in variables.yaml (the default source).",
+    )
+    parser.add_argument(
         "--from-log", metavar="FILE", type=Path,
         help="Reload the runner scale sets recorded in a previous overview log and "
              "redeploy them (e.g. to resume after a failed run), instead of discovering "
@@ -581,6 +672,19 @@ def main(argv: list[str] | None = None) -> int:
 
     preflight()
 
+    # Resolve the target cluster's kubeconfig once and export it for every
+    # subprocess (kubectl/helm here, plus the ansible-playbook runs). Playbooks
+    # re-derive KUBECONFIG from variables.yaml on their localhost plays, so a
+    # CLI override is additionally forwarded to them as an extra-var below.
+    kubeconfig, kubeconfig_source = resolve_kubeconfig(args.kubeconfig)
+    kubeconfig_is_override = kubeconfig_source == "cli"
+    os.environ["KUBECONFIG"] = kubeconfig
+    os.environ["K8S_AUTH_KUBECONFIG"] = kubeconfig
+    kubeconfig_override = kubeconfig if kubeconfig_is_override else None
+    _log(f"Target cluster kubeconfig: {kubeconfig} (from {kubeconfig_source})")
+    if kubeconfig_source == "default" and args.kubeconfig is None:
+        _log("  note: 'kubeconfig' is not set in variables.yaml; using the default.")
+
     # install-k8s-requirements SSHes to the nodes; fail fast (before any
     # termination) if the agent has no key rather than dying mid-run.
     if not args.skip_install_requirements and not args.skip_ssh_check:
@@ -602,7 +706,18 @@ def main(argv: list[str] | None = None) -> int:
         # Restore mode: take the scale set list from a saved manifest instead of
         # the live cluster (the sets may already be torn down after a failed run).
         _log(f"Loading runner scale sets from {reload_from}...")
-        scale_sets = [s for s in parse_overview(reload_from) if s.kind in kinds]
+        loaded_sets, overview_kubeconfig = parse_overview(reload_from)
+        if overview_kubeconfig:
+            overview_kubeconfig = os.path.abspath(os.path.expanduser(overview_kubeconfig))
+            if overview_kubeconfig != kubeconfig and args.kubeconfig is None:
+                raise RedeployError(
+                    f"overview targets kubeconfig {overview_kubeconfig}, but this worktree targets "
+                    f"{kubeconfig}. Pass --kubeconfig {shlex.quote(overview_kubeconfig)} to restore "
+                    "the recorded cluster, or pass an explicit different --kubeconfig to override it."
+                )
+            if overview_kubeconfig != kubeconfig:
+                _log(f"WARNING: overriding overview kubeconfig {overview_kubeconfig}")
+        scale_sets = [s for s in loaded_sets if s.kind in kinds]
         for s in scale_sets:
             _log(f"  loaded {s.label:24s} release={s.release} ns={s.namespace}")
     else:
@@ -627,7 +742,8 @@ def main(argv: list[str] | None = None) -> int:
     # Persist a fresh (timestamped, never-overwritten) manifest before touching
     # anything, so a hard failure still leaves a record of what to redeploy.
     overview_file = args.overview_file or default_overview_file()
-    emit_overview(scale_sets, overview_file, dry_run=args.dry_run, reloaded_from=reload_from)
+    emit_overview(scale_sets, overview_file, dry_run=args.dry_run, reloaded_from=reload_from,
+                  kubeconfig=kubeconfig, kubeconfig_is_override=kubeconfig_is_override)
 
     print_plan(scale_sets, skip_install=args.skip_install_requirements, reload_from=reload_from)
 
@@ -639,9 +755,9 @@ def main(argv: list[str] | None = None) -> int:
             for s in scale_sets:
                 terminate(s, dry_run=True)
         if not args.skip_install_requirements:
-            install_requirements(None, None, dry_run=True)
+            install_requirements(None, None, dry_run=True, kubeconfig=kubeconfig_override)
         for s in scale_sets:
-            recreate(s, dry_run=True)
+            recreate(s, dry_run=True, kubeconfig=kubeconfig_override)
         _log("")
         _log("Dry run: no changes made.")
         return 0
@@ -679,14 +795,14 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_install_requirements:
         _log("")
         _log("Step: install-k8s-requirements.yaml")
-        install_requirements(vault_pw, become_pw, dry_run=False)
+        install_requirements(vault_pw, become_pw, dry_run=False, kubeconfig=kubeconfig_override)
 
     _log("")
     _log("Step: redeploying runner scale sets")
     failures: list[str] = []
     for s in scale_sets:
         try:
-            recreate(s, dry_run=False)
+            recreate(s, dry_run=False, kubeconfig=kubeconfig_override)
         except RedeployError as exc:
             failures.append(f"{s.label}: {exc}")
             _log(f"  ERROR redeploying {s.label}: {exc}")

--- a/variables.yaml
+++ b/variables.yaml
@@ -4,6 +4,12 @@
 #
 # Authors: Dennis Maisenbacher (dennis.maisenbacher@wdc.com)
 
+# Kubeconfig used by playbooks and redeploy.py.
+kubeconfig: "~/.kube/config"
+
+# Per-cluster scratch directory derived from the kubeconfig file name.
+ansible_tmp_dir: "~/tmp-ansible-{{ kubeconfig | default('~/.kube/config', true) | basename }}"
+
 #Longhorn
 longhorn_helm_chart_url: "https://charts.longhorn.io"
 longhorn_version: "1.11.0"


### PR DESCRIPTION
Improve KubeVirt test VM provisioning and make cluster selection safe for
multi-worktree deployments.

- Select the target cluster through a per-worktree `kubeconfig` variable.
- Use the prebuilt Fedora blktests containerDisk as the default VM image.
- Install only runner packages missing from the selected image.
- Avoid the mpt3sas package fallback when no SAS HBA is attached.
- Suppress verbose kernel-module extraction output.
- Remove unused GPU, wireless, and sound drivers from custom kernels.